### PR TITLE
Handle keys in urls

### DIFF
--- a/blockservice.py
+++ b/blockservice.py
@@ -23,15 +23,15 @@ def get_pw(username):
     return None
 
 
-@app.route('/', methods=["GET", "HEAD"])
-def get():
-    return store.get("last", None)
+@app.route('/<key>', methods=["GET", "HEAD"])
+def get(key):
+    return store.get(key, None)
 
 
-@app.route('/', methods=["PUT"])
+@app.route('/<key>', methods=["PUT"])
 @auth.login_required
-def put():
-    store["last"] = request.data
+def put(key):
+    store[key] = request.data
     return ""
 
 

--- a/blockservice.py
+++ b/blockservice.py
@@ -31,6 +31,12 @@ def get(key):
 @app.route('/<key>', methods=["PUT"])
 @auth.login_required
 def put(key):
+    value = store.get(key, None)
+    if value:
+        if value == request.data:
+            return "", 202
+        else:
+            return "", 409
     store[key] = request.data
     return ""
 

--- a/test_blockservice.py
+++ b/test_blockservice.py
@@ -29,3 +29,18 @@ def test_put_and_get(app):
         r = app.get('/' + key)
         assert r.status_code == 200
         assert r.get_data() == data
+
+
+def test_indicate_repetition(app):
+    data = b"123"
+    creds = base64.b64encode(b'a:pass').decode('utf-8')
+    r = app.put('/adsf', data=data, headers={'Authorization': 'Basic ' + creds})
+    r = app.put('/adsf', data=data, headers={'Authorization': 'Basic ' + creds})
+    assert r.status_code == 202
+
+
+def test_signal_conflict_on_overwrite_attempt(app):
+    creds = base64.b64encode(b'a:pass').decode('utf-8')
+    r = app.put('/adsf', data=b"123", headers={'Authorization': 'Basic ' + creds})
+    r = app.put('/adsf', data=b"234", headers={'Authorization': 'Basic ' + creds})
+    assert r.status_code == 409

--- a/test_blockservice.py
+++ b/test_blockservice.py
@@ -10,19 +10,22 @@ def app():
 
 def test_put_invalid_login(app):
     creds = base64.b64encode(b'a:wrongpass').decode('utf-8')
-    r = app.put('/', data=b'123', headers={'Authorization': 'Basic ' + creds})
+    r = app.put('/asdf', data=b'123', headers={'Authorization': 'Basic ' + creds})
     assert r.status_code == 401
     creds = base64.b64encode(b'qwe:pass').decode('utf-8')
-    r = app.put('/', data=b'123', headers={'Authorization': 'Basic ' + creds})
+    r = app.put('/asdf', data=b'123', headers={'Authorization': 'Basic ' + creds})
     assert r.status_code == 401
 
 
 def test_put_and_get(app):
     for data in (b"123", b"456"):
         creds = base64.b64encode(b'a:pass').decode('utf-8')
-        r = app.put('/', data=data, headers={'Authorization': 'Basic ' + creds})
+        key = base64.b64encode(data).decode('utf-8')
+        r = app.put('/' + key, data=data, headers={'Authorization': 'Basic ' + creds})
         assert r.status_code == 200
 
-        r = app.get("/")
+    for data in (b"123", b"456"):
+        key = base64.b64encode(data).decode('utf-8')
+        r = app.get('/' + key)
         assert r.status_code == 200
         assert r.get_data() == data


### PR DESCRIPTION
`PUT /<key>` will now store the given data at `<key>`
`GET /<key>` will retrieve it.

In order to prevent overwriting of existing values as a DOS attack
we disallow overwriting values entirely.

The keys in claimchain are all sha256 hashes
so there is no need to worry about conflicts.

In case one attempts to write the same data for a given key again
we return a 202 response code because the client can just resume.

If the data is different we return a 409
because the client needs to act upon this.