### PR TITLE
Ci: run tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,12 @@ language: python
 dist: trusty
 python:
     - '3.5'
+    - '2.7'
 
-env:
-  matrix:
-    - TESTENV=lint
-    - TESTENV=py27
-#    - TESTENV=py35
+install: pip install tox-travis
 
 script:
-  - tox -e $TESTENV --recreate 
+  - tox
 
-#notifications:
-#  irc:
-#    channels:
-#      - "chat.freenode.net#autocrypt"
-#    on_success: change
-#    on_failure: change
-#    skip_join: true
-#  email:
-#    - pytest-commit@python.org
+notifications:
+  email: false

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,11 @@
 [tox]
-envlist = lint,py27 
+envlist = lint,py27,py35
 skip_missing_interpreters = True
+
+[travis]
+python =
+  2.7: py27, lint
+  3.5: py35
 
 [testenv]
 deps =
@@ -25,4 +30,4 @@ commands =
 
 
 [pytest]
-addopts = -rsxX 
+addopts = -rsxX


### PR DESCRIPTION
Currently this runs tox in py35 and py27. It also runs lint in a python 2.7 environment.

Not sure if this is exactly what we want but it's a start.
Also... using [tox-travis](https://tox-travis.readthedocs.io) - no idea if this is really useful. It matches the tox python version with the python version used in the vm.