### PR TITLE
fix loading config from file set in CCHTTPSERVER_CONFIG

### DIFF
--- a/cchttpserver/app.py
+++ b/cchttpserver/app.py
@@ -10,7 +10,7 @@ def create_app(test_config=None):
     auth = HTTPBasicAuth()
 
     if test_config is None:
-        get_config_path()
+        p = get_config_path()
         app.config.from_pyfile(p, silent=False)
         pprint.pprint(app.config)
     else:


### PR DESCRIPTION
In https://travis-ci.org/nextleap-project/muacryptcc/jobs/457966148 cchttpserver failed like this:
```
  File "/opt/python/3.5.6/lib/python3.5/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/python/3.5.6/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/cchttpserver/__main__.py", line 5, in <module>
    main()
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/cchttpserver/app.py", line 84, in main
    app = create_app()
  File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/cchttpserver/app.py", line 14, in create_app
    app.config.from_pyfile(p, silent=False)
NameError: name 'p' is not defined
```